### PR TITLE
fix: adds index.ts to excludes

### DIFF
--- a/synth.py
+++ b/synth.py
@@ -60,6 +60,7 @@ s.copy(
     excludes=[
         ".kokoro/continuous/node12/samples-test.cfg",
         ".kokoro/presubmit/node12/samples-test.cfg",
+        "src/index.ts",
     ],
 )
 


### PR DESCRIPTION
This PR adds the `src/index.ts` file to the list of files to exclude during the template copying phase in `synth.py`.

Related to #27.
