### PR TITLE
build: stop providing hint for default_version

### DIFF
--- a/synth.metadata
+++ b/synth.metadata
@@ -3,23 +3,16 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/nodejs-ai-platform.git",
-        "sha": "ccc19537477a57ab36b13072ff6d569eba29d0a7"
+        "remote": "git@github.com:googleapis/nodejs-ai-platform.git",
+        "sha": "554be102437a9e0bf10449d4579dbb3f201de00a"
       }
     },
     {
       "git": {
         "name": "googleapis",
         "remote": "https://github.com/googleapis/googleapis.git",
-        "sha": "5477122b3e8037a1dc5bc920536158edbd151dc4",
-        "internalRef": "361273630"
-      }
-    },
-    {
-      "git": {
-        "name": "synthtool",
-        "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "57c23fa5705499a4181095ced81f0ee0933b64f6"
+        "sha": "d652c6370bf66e325da6ac9ad82989fe7ee7bb4b",
+        "internalRef": "362183999"
       }
     }
   ],

--- a/synth.py
+++ b/synth.py
@@ -49,9 +49,7 @@ for version in versions:
 # Copy common templates
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library(
-    source_location="build/src",
-    versions=versions,
-    default_version=default_version,
+    source_location="build/src"
 )
 # We override the default sample configuration with a custom
 # environment file:


### PR DESCRIPTION
By omitting default_version, we provide a hint to the generator not to generate src/index.ts