### PR TITLE
test: added back BQ tabular dataset sample test

### DIFF
--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -18,7 +18,7 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const {after, it} = require('mocha');
+const {after, describe, it} = require('mocha');
 
 const uuid = require('uuid').v4;
 const cp = require('child_process');
@@ -32,23 +32,25 @@ const location = process.env.LOCATION;
 
 let datasetId;
 
-it('should create a new bigquery tabular dataset in the parent resource', async () => {
-  const stdout = execSync(
-    `node ./create-dataset-tabular-bigquery.js ${datasetDisplayName} \
+describe('AI platform create dataset tabular bigquery', () => {
+  it('should create a new bigquery tabular dataset in the parent resource', async () => {
+    const stdout = execSync(
+      `node ./create-dataset-tabular-bigquery.js ${datasetDisplayName} \
                                                   ${bigquerySourceUri} \
                                                   ${project} ${location}`,
-    {
+      {
+        cwd,
+      }
+    );
+    assert.match(stdout, /Create dataset tabular bigquery response/);
+    datasetId = stdout
+      .split(`/locations/${location}/datasets/`)[1]
+      .split('/')[0]
+      .split('/')[0];
+  });
+  after('should delete created dataset', async () => {
+    execSync(`node ./delete-dataset.js ${datasetId} ${project} ${location}`, {
       cwd,
-    }
-  );
-  assert.match(stdout, /Create dataset tabular bigquery response/);
-  datasetId = stdout
-    .split(`/locations/${location}/datasets/`)[1]
-    .split('/')[0]
-    .split('/')[0];
-});
-after('should delete created dataset', async () => {
-  execSync(`node ./delete-dataset.js ${datasetId} ${project} ${location}`, {
-    cwd,
+    });
   });
 });

--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -27,7 +27,7 @@ const cwd = path.join(__dirname, '..');
 
 const datasetDisplayName = `temp_create_dataset_tables_bigquery_test_${uuid()}`;
 const bigquerySourceUri =
-  'bq://prj-ucaip-tutorials.bigquery_dataset.walmart_triptrain_train';
+  'bq://ucaip-sample-tests.table_test.all_bq_types';
 const project = process.env.CAIP_PROJECT_ID;
 const location = process.env.LOCATION;
 
@@ -44,7 +44,7 @@ it('should create a new bigquery tabular dataset in the parent resource', async 
   );
   assert.match(stdout, /Create dataset tabular bigquery response/);
   datasetId = stdout
-    .split('/locations/us-central1/datasets/')[1]
+    .split(`/locations/${location}/datasets/`)[1]
     .split('/')[0]
     .split('/')[0];
 });

--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -18,7 +18,7 @@
 
 const path = require('path');
 const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
+const {after, it} = require('mocha');
 
 const uuid = require('uuid').v4;
 const cp = require('child_process');

--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -17,12 +17,12 @@
 'use strict';
 
 const path = require('path');
-const {assert} = require('chai');
-const {after, describe, it} = require('mocha');
+const { assert } = require('chai');
+const { after, describe, it } = require('mocha');
 
 const uuid = require('uuid').v4;
 const cp = require('child_process');
-const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
+const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
 const cwd = path.join(__dirname, '..');
 
 const datasetDisplayName = `temp_create_dataset_tables_bigquery_test_${uuid()}`;
@@ -33,26 +33,23 @@ const location = process.env.LOCATION;
 
 let datasetId;
 
-// Refs: https://github.com/googleapis/nodejs-ai-platform/issues/187
-describe.skip('AI platform create dataset tabular bigquery', () => {
-  it('should create a new bigquery tabular dataset in the parent resource', async () => {
-    const stdout = execSync(
-      `node ./create-dataset-tabular-bigquery.js ${datasetDisplayName} \
+it('should create a new bigquery tabular dataset in the parent resource', async () => {
+  const stdout = execSync(
+    `node ./create-dataset-tabular-bigquery.js ${datasetDisplayName} \
                                                   ${bigquerySourceUri} \
                                                   ${project} ${location}`,
-      {
-        cwd,
-      }
-    );
-    assert.match(stdout, /Create dataset tabular bigquery response/);
-    datasetId = stdout
-      .split('/locations/us-central1/datasets/')[1]
-      .split('/')[0]
-      .split('/')[0];
-  });
-  after('should delete created dataset', async () => {
-    execSync(`node ./delete-dataset.js ${datasetId} ${project} ${location}`, {
+    {
       cwd,
-    });
+    }
+  );
+  assert.match(stdout, /Create dataset tabular bigquery response/);
+  datasetId = stdout
+    .split('/locations/us-central1/datasets/')[1]
+    .split('/')[0]
+    .split('/')[0];
+});
+after('should delete created dataset', async () => {
+  execSync(`node ./delete-dataset.js ${datasetId} ${project} ${location}`, {
+    cwd,
   });
 });

--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -17,12 +17,12 @@
 'use strict';
 
 const path = require('path');
-const { assert } = require('chai');
-const { after, describe, it } = require('mocha');
+const {assert} = require('chai');
+const {after, describe, it} = require('mocha');
 
 const uuid = require('uuid').v4;
 const cp = require('child_process');
-const execSync = cmd => cp.execSync(cmd, { encoding: 'utf-8' });
+const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
 const datasetDisplayName = `temp_create_dataset_tables_bigquery_test_${uuid()}`;

--- a/samples/test/create-dataset-tabular-bigquery.test.js
+++ b/samples/test/create-dataset-tabular-bigquery.test.js
@@ -26,8 +26,7 @@ const execSync = cmd => cp.execSync(cmd, {encoding: 'utf-8'});
 const cwd = path.join(__dirname, '..');
 
 const datasetDisplayName = `temp_create_dataset_tables_bigquery_test_${uuid()}`;
-const bigquerySourceUri =
-  'bq://ucaip-sample-tests.table_test.all_bq_types';
+const bigquerySourceUri = 'bq://ucaip-sample-tests.table_test.all_bq_types';
 const project = process.env.CAIP_PROJECT_ID;
 const location = process.env.LOCATION;
 


### PR DESCRIPTION
* Updated BQ table used in test
* Fixed location parameter that was hardcoded to `us-central1`
* Removed skip statement after confirming test is working

Fixes #186, fixes #187  🦕
