### PR TITLE
chore: add cloudshell URL to linkinator config

### DIFF
--- a/linkinator.config.json
+++ b/linkinator.config.json
@@ -2,6 +2,7 @@
   "recurse": true,
   "skip": [
     "https://codecov.io/gh/googleapis/",
+    "https://console.cloud.google.com/cloudshell/open",
     "www.googleapis.com",
     "img.shields.io"
   ],


### PR DESCRIPTION
This will suppress linkinator false positives.